### PR TITLE
Ensure onboarding finish opens app

### DIFF
--- a/src/screens/onboarding/FinishScreen.tsx
+++ b/src/screens/onboarding/FinishScreen.tsx
@@ -2,17 +2,13 @@ import React, { useState } from 'react';
 import { Text, Button, StyleSheet, Alert } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { StackNavigationProp } from '@react-navigation/stack';
-import { CommonActions } from '@react-navigation/native';
-import { AppStackParamList } from '../../types';
 import { useOnboarding } from '../../contexts/OnboardingContext';
 import { useAuth } from '../../contexts/AuthContext';
 import { db, doc, setDoc } from '../../services/firebase';
 
-type Nav = StackNavigationProp<AppStackParamList, any>;
-type Props = { navigation: Nav; onFinish?: () => void };
+type Props = { onFinish?: () => void } & Record<string, any>;
 
-const FinishScreen: React.FC<Props> = ({ navigation, onFinish }) => {
+const FinishScreen: React.FC<Props> = ({ onFinish }) => {
   const { profile } = useOnboarding();
   const { user } = useAuth();
   const [saving, setSaving] = useState(false);
@@ -32,21 +28,6 @@ const FinishScreen: React.FC<Props> = ({ navigation, onFinish }) => {
         await setDoc(userRef, profile, { merge: true });
         await setDoc(doc(userRef, 'goals', 'first'), goal, { merge: true });
       }
-
-      navigation.dispatch(
-        CommonActions.reset({
-          index: 0,
-          routes: [
-            {
-              name: 'Home',
-              state: {
-                index: 0,
-                routes: [{ name: 'Dashboard' }],
-              } as any,
-            },
-          ],
-        })
-      );
 
       onFinish?.();
     } catch (e) {


### PR DESCRIPTION
## Summary
- remove attempt to reset navigation to a non-existent route
- trigger onFinish after saving profile so RootNavigator shows main app

## Testing
- `npm test` (fails: Missing script: "test")
- `npx tsc --noEmit` (fails: Module '../services/WalletService' declares 'Currency' locally, but it is not exported. etc.)

------
https://chatgpt.com/codex/tasks/task_e_689b9aa77fa883298ff12bec2740e6f0