### PR TITLE
feat: add firebase usage flag

### DIFF
--- a/app.json
+++ b/app.json
@@ -19,7 +19,8 @@
       "EXPO_PUBLIC_FB_PROJECT_ID": "",
       "EXPO_PUBLIC_FB_STORAGE_BUCKET": "",
       "EXPO_PUBLIC_FB_MESSAGING_SENDER_ID": "",
-      "EXPO_PUBLIC_FB_APP_ID": ""
+      "EXPO_PUBLIC_FB_APP_ID": "",
+      "EXPO_PUBLIC_USE_FIREBASE": "false"
     }
   }
 }


### PR DESCRIPTION
## Summary
- add EXPO_PUBLIC_USE_FIREBASE default flag in expo extra config

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ba168ed1483298ec05f26c3fdb5bc