### PR TITLE
Add Firebase dispatcher with real and stub implementations

### DIFF
--- a/src/services/firebase.real.ts
+++ b/src/services/firebase.real.ts
@@ -1,0 +1,115 @@
+/**
+ * Firebase v9/10 modular implementation.
+ */
+
+import { initializeApp, type FirebaseApp } from 'firebase/app';
+import {
+  getAuth,
+  onAuthStateChanged as fbOnAuthStateChanged,
+  signInWithEmailAndPassword as fbSignInWithEmailAndPassword,
+  signInAnonymously as fbSignInAnonymously,
+  signOut as fbSignOut,
+  type Auth,
+} from 'firebase/auth';
+import {
+  getFirestore,
+  collection as fbCollection,
+  doc as fbDoc,
+  addDoc as fbAddDoc,
+  setDoc as fbSetDoc,
+  getDoc as fbGetDoc,
+  updateDoc as fbUpdateDoc,
+  deleteDoc as fbDeleteDoc,
+  type Firestore,
+  type CollectionReference,
+  type DocumentReference,
+  type DocumentData,
+  type SetOptions,
+} from 'firebase/firestore';
+
+// Read config from Expo env (safe if left empty — wrapper will no-op)
+const cfg = {
+  apiKey: process.env.EXPO_PUBLIC_FB_API_KEY || '',
+  authDomain: process.env.EXPO_PUBLIC_FB_AUTH_DOMAIN || '',
+  projectId: process.env.EXPO_PUBLIC_FB_PROJECT_ID || '',
+  storageBucket: process.env.EXPO_PUBLIC_FB_STORAGE_BUCKET || '',
+  messagingSenderId: process.env.EXPO_PUBLIC_FB_MESSAGING_SENDER_ID || '',
+  appId: process.env.EXPO_PUBLIC_FB_APP_ID || '',
+};
+
+export const isFirebaseConfigured = Object.values(cfg).every(
+  (v) => typeof v === 'string' && v.length > 0
+);
+
+let firebaseApp: FirebaseApp | undefined;
+let auth: Auth | undefined;
+let db: Firestore | undefined;
+
+try {
+  if (isFirebaseConfigured) {
+    firebaseApp = initializeApp(cfg);
+    auth = getAuth(firebaseApp);
+    db = getFirestore(firebaseApp);
+  }
+} catch (e) {
+  console.warn('Firebase init failed:', e);
+  firebaseApp = undefined;
+  auth = undefined;
+  db = undefined;
+}
+
+// Export initialized handles (may be undefined if not configured)
+export { firebaseApp, auth, db };
+
+/** ---- Re-exports so app never imports firebase/* directly ---- */
+
+// Auth helpers
+export const onAuthStateChanged = (
+  a: Auth | undefined,
+  cb: (user: any) => void
+) => (a ? fbOnAuthStateChanged(a, cb) : () => {});
+
+export const signInWithEmailAndPassword = async (
+  a: Auth | undefined,
+  email: string,
+  pass: string
+) => {
+  if (a) await fbSignInWithEmailAndPassword(a, email, pass);
+};
+
+export const signInAnonymously = async (a: Auth | undefined) => {
+  if (a) await fbSignInAnonymously(a);
+};
+
+export const signOut = async (a: Auth | undefined) => {
+  if (a) await fbSignOut(a);
+};
+
+// Firestore helpers
+type ColRef = CollectionReference<DocumentData>;
+type DocRef = DocumentReference<DocumentData>;
+
+export const collection = (root: Firestore | DocRef, path: string): ColRef => {
+  if (!root) throw new Error('Firestore not configured');
+  return fbCollection(root as any, path);
+};
+
+export const doc = (
+  root: Firestore | DocRef | ColRef,
+  ...segments: string[]
+): DocRef => {
+  if (!root) throw new Error('Firestore not configured');
+  return fbDoc(root as any, ...segments);
+};
+
+export const addDoc = async (col: ColRef, data: any) => fbAddDoc(col, data);
+
+export const setDoc = async (d: DocRef, data: any, opts?: SetOptions) =>
+  opts ? fbSetDoc(d, data, opts) : fbSetDoc(d, data);
+
+export const getDoc = async (d: DocRef) => fbGetDoc(d);
+
+export const updateDoc = async (d: DocRef, data: any) => fbUpdateDoc(d, data);
+
+export const deleteDoc = async (d: DocRef) => fbDeleteDoc(d);
+

--- a/src/services/firebase.stub.ts
+++ b/src/services/firebase.stub.ts
@@ -1,0 +1,64 @@
+/**
+ * No-op Firebase implementation used when Firebase is disabled.
+ */
+
+import type { FirebaseApp } from 'firebase/app';
+import type { Auth } from 'firebase/auth';
+import type {
+  Firestore,
+  CollectionReference,
+  DocumentReference,
+  DocumentData,
+  SetOptions,
+} from 'firebase/firestore';
+
+export const isFirebaseConfigured = false;
+
+export const firebaseApp: FirebaseApp | undefined = undefined;
+export const auth: Auth | undefined = undefined;
+export const db: Firestore | undefined = undefined;
+
+// Auth helpers
+export const onAuthStateChanged = (
+  _a: Auth | undefined,
+  _cb: (user: any) => void
+) => () => {};
+
+export const signInWithEmailAndPassword = async (
+  _a: Auth | undefined,
+  _email: string,
+  _pass: string
+) => {};
+
+export const signInAnonymously = async (_a: Auth | undefined) => {};
+
+export const signOut = async (_a: Auth | undefined) => {};
+
+// Firestore helpers
+type ColRef = CollectionReference<DocumentData>;
+type DocRef = DocumentReference<DocumentData>;
+
+export const collection = (
+  _root: Firestore | DocRef,
+  _path: string
+): ColRef => null as any;
+
+export const doc = (
+  _root: Firestore | DocRef | ColRef,
+  ..._segments: string[]
+): DocRef => null as any;
+
+export const addDoc = async (_col: ColRef, _data: any) => {};
+
+export const setDoc = async (
+  _d: DocRef,
+  _data: any,
+  _opts?: SetOptions
+) => {};
+
+export const getDoc = async (_d: DocRef) => undefined;
+
+export const updateDoc = async (_d: DocRef, _data: any) => {};
+
+export const deleteDoc = async (_d: DocRef) => {};
+

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -1,120 +1,29 @@
+/**
+ * Dispatcher that selects the real or stub Firebase implementation
+ * based on EXPO_PUBLIC_USE_FIREBASE environment variable.
+ */
 
-// src/services/firebase.ts — Firebase v9 modular setup (no Snack compat)
+type FirebaseModule = typeof import('./firebase.real');
 
-import { initializeApp, type FirebaseApp } from 'firebase/app';
-import {
-  getAuth,
-  onAuthStateChanged as fbOnAuthStateChanged,
-  signInWithEmailAndPassword as fbSignInWithEmailAndPassword,
-  signInAnonymously as fbSignInAnonymously,
-  signOut as fbSignOut,
-  type Auth,
-} from 'firebase/auth';
-import {
-  getFirestore,
-  collection as fbCollection,
-  doc as fbDoc,
-  addDoc as fbAddDoc,
-  setDoc as fbSetDoc,
-  getDoc as fbGetDoc,
-  updateDoc as fbUpdateDoc,
-  deleteDoc as fbDeleteDoc,
-  type Firestore,
-  type CollectionReference,
-  type DocumentReference,
-  type DocumentData,
-  type SetOptions,
-} from 'firebase/firestore';
-// src/services/firebase.ts — Firebase v8 wrapper for Snack/Expo
+const firebase: FirebaseModule =
+  process.env.EXPO_PUBLIC_USE_FIREBASE === 'true'
+    ? require('./firebase.real')
+    : require('./firebase.stub');
 
-import firebase from 'firebase/app';
-import 'firebase/auth';
-import 'firebase/firestore';
+export const isFirebaseConfigured = firebase.isFirebaseConfigured;
+export const firebaseApp = firebase.firebaseApp;
+export const auth = firebase.auth;
+export const db = firebase.db;
+export const onAuthStateChanged = firebase.onAuthStateChanged;
+export const signInWithEmailAndPassword = firebase.signInWithEmailAndPassword;
+export const signInAnonymously = firebase.signInAnonymously;
+export const signOut = firebase.signOut;
+export const collection = firebase.collection;
+export const doc = firebase.doc;
+export const addDoc = firebase.addDoc;
+export const setDoc = firebase.setDoc;
+export const getDoc = firebase.getDoc;
+export const updateDoc = firebase.updateDoc;
+export const deleteDoc = firebase.deleteDoc;
 
-
-// Read config from Expo env (safe if left empty — wrapper will no-op)
-const cfg = {
-  apiKey: process.env.EXPO_PUBLIC_FB_API_KEY || '',
-  authDomain: process.env.EXPO_PUBLIC_FB_AUTH_DOMAIN || '',
-  projectId: process.env.EXPO_PUBLIC_FB_PROJECT_ID || '',
-  storageBucket: process.env.EXPO_PUBLIC_FB_STORAGE_BUCKET || '',
-  messagingSenderId: process.env.EXPO_PUBLIC_FB_MESSAGING_SENDER_ID || '',
-  appId: process.env.EXPO_PUBLIC_FB_APP_ID || '',
-};
-
-export const isFirebaseConfigured = Object.values(cfg).every(
-  (v) => typeof v === 'string' && v.length > 0
-);
-
-let firebaseApp: FirebaseApp | undefined;
-let auth: Auth | undefined;
-let db: Firestore | undefined;
-
-try {
-  if (isFirebaseConfigured) {
-    firebaseApp = initializeApp(cfg);
-    auth = getAuth(firebaseApp);
-    db = getFirestore(firebaseApp);
-  }
-} catch (e) {
-  console.warn('Firebase init failed:', e);
-  firebaseApp = undefined;
-  auth = undefined;
-  db = undefined;
-}
-
-// Export initialized handles (may be undefined if not configured)
-export { firebaseApp, auth, db };
-
-/** ---- Re-exports so app never imports firebase/* directly ---- */
-
-// Auth helpers
-export const onAuthStateChanged = (
-  a: Auth | undefined,
-  cb: (user: any) => void
-) => (a ? fbOnAuthStateChanged(a, cb) : () => {});
-
-export const signInWithEmailAndPassword = async (
-  a: Auth | undefined,
-  email: string,
-  pass: string
-) => {
-  if (a) await fbSignInWithEmailAndPassword(a, email, pass);
-};
-
-export const signInAnonymously = async (a: Auth | undefined) => {
-  if (a) await fbSignInAnonymously(a);
-};
-
-export const signOut = async (a: Auth | undefined) => {
-  if (a) await fbSignOut(a);
-};
-
-// Firestore helpers
-type ColRef = CollectionReference<DocumentData>;
-type DocRef = DocumentReference<DocumentData>;
-
-export const collection = (root: Firestore | DocRef, path: string): ColRef => {
-  if (!root) throw new Error('Firestore not configured');
-  return fbCollection(root as any, path);
-};
-
-export const doc = (
-  root: Firestore | DocRef | ColRef,
-  ...segments: string[]
-): DocRef => {
-  if (!root) throw new Error('Firestore not configured');
-  return fbDoc(root as any, ...segments);
-};
-
-export const addDoc = async (col: ColRef, data: any) => fbAddDoc(col, data);
-
-export const setDoc = async (d: DocRef, data: any, opts?: SetOptions) =>
-  opts ? fbSetDoc(d, data, opts) : fbSetDoc(d, data);
-
-export const getDoc = async (d: DocRef) => fbGetDoc(d);
-
-export const updateDoc = async (d: DocRef, data: any) => fbUpdateDoc(d, data);
-
-export const deleteDoc = async (d: DocRef) => fbDeleteDoc(d);
-
+export default firebase;


### PR DESCRIPTION
## Summary
- split Firebase service into real and stub modules
- dispatch to real or stub Firebase based on `EXPO_PUBLIC_USE_FIREBASE`

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails: Module 'WalletService' declares 'Currency' locally, but it is not exported, ...)*

------
https://chatgpt.com/codex/tasks/task_e_689ba204877483299ffc28013297e23f