### PR TITLE
Reset navigation after onboarding

### DIFF
--- a/src/screens/onboarding/FinishScreen.tsx
+++ b/src/screens/onboarding/FinishScreen.tsx
@@ -2,13 +2,14 @@ import React, { useState } from 'react';
 import { Text, Button, StyleSheet, Alert } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { CommonActions } from '@react-navigation/native';
 import { useOnboarding } from '../../contexts/OnboardingContext';
 import { useAuth } from '../../contexts/AuthContext';
 import { db, doc, setDoc } from '../../services/firebase';
 
 type Props = { onFinish?: () => void } & Record<string, any>;
 
-const FinishScreen: React.FC<Props> = ({ onFinish }) => {
+const FinishScreen: React.FC<Props> = ({ navigation, onFinish }) => {
   const { profile } = useOnboarding();
   const { user } = useAuth();
   const [saving, setSaving] = useState(false);
@@ -28,6 +29,18 @@ const FinishScreen: React.FC<Props> = ({ onFinish }) => {
         await setDoc(userRef, profile, { merge: true });
         await setDoc(doc(userRef, 'goals', 'first'), goal, { merge: true });
       }
+
+      navigation.dispatch(
+        CommonActions.reset({
+          index: 0,
+          routes: [
+            {
+              name: 'Home',
+              state: { index: 0, routes: [{ name: 'Dashboard' }] },
+            },
+          ],
+        }),
+      );
 
       onFinish?.();
     } catch (e) {


### PR DESCRIPTION
## Summary
- Reset navigation stack to Home > Dashboard after onboarding persistence completes
- Add CommonActions import and dispatch reset action from FinishScreen

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'node', 'react', 'react-native')*
- `npm install` *(fails: peer dependency conflict for @types/react)*

------
https://chatgpt.com/codex/tasks/task_e_689ba4e108f48329b2fccd01530dc64c