### PR TITLE
feat: add toggles to isolate native crashes

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,9 @@
 // Ensure native modules are initialized even if Snack boots App.tsx directly
 import 'react-native-gesture-handler';
 import { enableScreens } from 'react-native-screens';
-enableScreens(true);
+// Allow disabling native screens during development to troubleshoot crashes
+const useNativeScreens = process.env.EXPO_PUBLIC_USE_NATIVE_SCREENS !== 'false';
+enableScreens(useNativeScreens);
 
 import React, { useEffect, useState } from 'react';
 import { View } from 'react-native';

--- a/app.json
+++ b/app.json
@@ -6,6 +6,7 @@
     "orientation": "portrait",
     "scheme": "companionspay",
     "icon": null,
+    "jsEngine": "jsc",
     "splash": {
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
@@ -20,7 +21,8 @@
       "EXPO_PUBLIC_FB_STORAGE_BUCKET": "",
       "EXPO_PUBLIC_FB_MESSAGING_SENDER_ID": "",
       "EXPO_PUBLIC_FB_APP_ID": "",
-      "EXPO_PUBLIC_USE_FIREBASE": "false"
+      "EXPO_PUBLIC_USE_FIREBASE": "false",
+      "EXPO_PUBLIC_USE_NATIVE_SCREENS": "false"
     }
   }
 }


### PR DESCRIPTION
## Summary
- allow disabling native screens via EXPO_PUBLIC_USE_NATIVE_SCREENS
- fall back to JSC instead of Hermes
- load Firebase only when explicitly enabled

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bd09eb59083298337fd8fbe5ac1c5